### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# People marked here will be automatically requested for a review
+# when the code that they own is touched.
+# https://help.github.com/articles/about-codeowners/
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+* @szul
+
+# Library Owners
+/libraries/botbuilder-config/ @szul
+/libraries/botbuilder-azuretablestorage/ @szul
+/libraries/botbuilder-dialog-prompts/ @szul
+/libraries/botbuilder-text-analytics-middleware/ @szul


### PR DESCRIPTION
Would it be an idea to add a [CODEOWNERS file](https://help.github.com/articles/about-codeowners/
) in all botbuilder-community repositories to track down the codeowners per package? When there will be more people contributing to the `botbuilder-community-js` project, this can be a nice way to make sure any changes are reviewed by the right people. Especially when there are multiple libraries in the same repository.

An example of a community project which is using CODEOWNERS is [HomeAssistant](https://github.com/home-assistant/home-assistant/blob/dev/CODEOWNERS). 

Should there be a team like @botbuilder-community/js which is the default codeowner for all new PR's within the JS repository.

>You can use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.

>Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin or owner permissions has enabled required reviews, they also can optionally require approval from a code owner before the author can merge a pull request in the repository.
