### PR TITLE
feat: Add support for a custom endpoint on botbuilder-storage-dynamodb

### DIFF
--- a/libraries/botbuilder-storage-dynamodb/README.md
+++ b/libraries/botbuilder-storage-dynamodb/README.md
@@ -5,15 +5,16 @@ This is a simple storage adapter for storing BotState in DynamoDB. To use:
 ```js
 import { DynamoDBStorage } from '@botbuildercommunity/storage-dynamodb';
 
-const dynamoDBStorage = new DynamoDBStorage(
-    'table-name',
-    'us-east-1',
-    {
+const dynamoDBStorage = new DynamoDBStorage({
+    tableName: 'table-name',
+    region: 'us-east-1',
+    credentials: { // optional
         accessKeyId: 'accessKeyId',
         secretAccessKey: 'secretAccessKey',
         sessionToken: 'sessionToken' // optional
-    }
-);
+    },
+    endpoint: 'http://foo' // optional
+});
 
 const conversationState = new ConversationState(dynamoDBStorage);
 const userState = new UserState(dynamoDBStorage);

--- a/libraries/botbuilder-storage-dynamodb/package.json
+++ b/libraries/botbuilder-storage-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botbuildercommunity/storage-dynamodb",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "DynamoDB storage option for the Microsoft Bot Framework",
   "keywords": [
     "botbuilder",


### PR DESCRIPTION
Description
---

This change updates botbuilder-storage-dynamodb to support a custom endpoint - useful when using something like localstack locally, and you want to point the adapter to that instead.

Unfortunately, this is an additional optional parameter to the adapter, and so to make the API simpler, adopting an options pattern for all parameters. This will enable easier extension of parameters in future. Given this adapter has only been downloaded ~40 times in the last week, it seems to be fairly low impact to release a new major version.

Test Plan
---
- [x] Run localstack (which has a custom endpoint URL)
- [x] Update our running application to conform to the new API shape of this plugin and set the endpoint option
- [x] Verify app is able to interface with localstack
- [x] Unit tests